### PR TITLE
[SYNC] Per lock/unlock request new consumption queue is created, fixes and improvements

### DIFF
--- a/connector/common/src/adapters/queue/rabbitMq/Exchange.ts
+++ b/connector/common/src/adapters/queue/rabbitMq/Exchange.ts
@@ -49,6 +49,8 @@ export class Exchange implements ExchangeInterface {
       return undefined;
     }
 
+    this._logger.info(`Publishing to channel ${message}`);
+
     return this._channel.publish(this._name, "", Buffer.from(message));
   }
 

--- a/connector/common/src/adapters/queue/rabbitMq/ExchangeQueue.ts
+++ b/connector/common/src/adapters/queue/rabbitMq/ExchangeQueue.ts
@@ -116,6 +116,7 @@ export class ExchangeQueue {
     }
 
     if (this._channel === undefined) {
+      this._logger.error("Channel not initialized", ExchangeQueue.name);
       return undefined;
     }
 
@@ -129,8 +130,8 @@ export class ExchangeQueue {
   }
 
   public async consume(): Promise<boolean> {
-    await this.init();
-    if (this._channel === undefined) {
+    const initiated = await this.init();
+    if (initiated === false || this._channel === undefined) {
       return false;
     }
 

--- a/connector/processors/fromTcpInterfaceMessages/src/handler/onData/HandleFirstPaket.ts
+++ b/connector/processors/fromTcpInterfaceMessages/src/handler/onData/HandleFirstPaket.ts
@@ -66,10 +66,23 @@ export class HandleFirstPaket implements HandleFirstPaketInterface {
       vehicleModelByPaket?.lock?.state !== undefined &&
       vehicleId !== undefined
     ) {
-      await this._forwardLockAttribute.run(
+      const forwarded = await this._forwardLockAttribute.run(
         vehicleModelByPaket.lock.state.state,
         vehicleId,
       );
+
+      if (forwarded !== true) {
+        this._logger.error(
+          `Forward lock attribute failed`,
+          HandleFirstPaket.name,
+        );
+        return;
+      } else {
+        this._logger.info(
+          `Forward lock attribute succeeded`,
+          HandleFirstPaket.name,
+        );
+      }
     }
 
     await this.acknowledge(socketId, messageLineContext);

--- a/connector/processors/fromTcpInterfaceMessages/src/handler/onData/HandleNotFirstPaket.ts
+++ b/connector/processors/fromTcpInterfaceMessages/src/handler/onData/HandleNotFirstPaket.ts
@@ -103,10 +103,23 @@ export class HandleNotFirstPaket implements HandleNotFirstPaketInterface {
     }
 
     if (vehicleModelByPaket?.lock?.state !== undefined) {
-      await this._forwardLockAttribute.run(
+      const forwarded = await this._forwardLockAttribute.run(
         vehicleModelByPaket.lock.state.state,
         vehicleStored.id,
       );
+
+      if (forwarded !== true) {
+        this._logger.error(
+          `Forward lock attribute failed`,
+          HandleNotFirstPaket.name,
+        );
+        return;
+      } else {
+        this._logger.info(
+          `Forward lock attribute succeeded`,
+          HandleNotFirstPaket.name,
+        );
+      }
     }
 
     await this.acknowledge(socketId, messageLineContext);

--- a/connector/tcpInterface/src/socket/to/ProcessActionRequests.ts
+++ b/connector/tcpInterface/src/socket/to/ProcessActionRequests.ts
@@ -8,6 +8,7 @@ export class ProcessActionRequests {
   }
 
   public run(): void {
+    // TODO: catch consumption errors
     this._toTcpInterfaceMessage
       .consume()
       .then(() => {});

--- a/connector/userApi/src/index.ts
+++ b/connector/userApi/src/index.ts
@@ -22,7 +22,6 @@ import { SendActionRequest } from "../../common/src/vehicle/model/actions/SendAc
 import { WorkerQueue } from "../../common/src/adapters/queue/rabbitMq/WorkerQueue.ts";
 import { Unknown as JsonVehicleToVehicleUnknown } from "../../common/src/vehicle/json/jsonVehicleToVehicle/models/Unknown.ts";
 import { LockableScooter as VehicleToJsonVehicleLockableScooter } from "../../common/src/vehicle/json/vehicleToJsonVehicle/models/LockableScooter.ts";
-import { ExchangeQueue } from "../../common/src/adapters/queue/rabbitMq/ExchangeQueue.ts";
 import { Exchange } from "../../common/src/adapters/queue/rabbitMq/Exchange.ts";
 import { ActionStateFromJson } from "../../common/src/vehicle/model/actions/json/ActionStateFromJson.ts";
 import { Channel } from "../../common/src/adapters/queue/rabbitMq/Channel.ts";
@@ -50,6 +49,7 @@ dotenv.config();
 const filesPathShared = pathResolver.run(
   process.env.FILES_PATH_SHARED || "tmp",
 );
+const applicationName = "userApi";
 
 const logger = new Logger(LogLevels.DEBUG_LEVEL);
 
@@ -96,6 +96,7 @@ const exchange = new Exchange(rabbitMqChannel, "action_responses", logger);
 
 const handleLockResponseV2 = new HandleLockResponseV2(
   new ActionStateFromJson(logger),
+  logger,
 );
 
 const server = new HttpExpressServer(
@@ -108,27 +109,19 @@ const server = new HttpExpressServer(
     new GetByImei(vehicleRepository),
     new Lock(
       vehicleRepository,
-      new ExchangeQueue(
-        rabbitMqChannel,
-        handleLockResponseV2,
-        handleLockResponseV2,
-        exchange,
-        "userApi",
-        logger,
-        true,
-      ),
+      rabbitMqChannel,
+      handleLockResponseV2,
+      exchange,
+      applicationName,
+      logger,
     ),
     new Unlock(
       vehicleRepository,
-      new ExchangeQueue(
-        rabbitMqChannel,
-        handleLockResponseV2,
-        handleLockResponseV2,
-        exchange,
-        "userApi",
-        logger,
-        true,
-      ),
+      rabbitMqChannel,
+      handleLockResponseV2,
+      exchange,
+      applicationName,
+      logger,
     ),
     new UpdateModelName(vehicleRepository),
     new GetMap(vehicleRepository),

--- a/connector/userApi/src/routes/v1/vehicle/Lock.ts
+++ b/connector/userApi/src/routes/v1/vehicle/Lock.ts
@@ -1,5 +1,9 @@
 import { Request, Response, Router as ExpressRouter } from "express";
 import { v4 as uuidv4 } from "uuid";
+import LoggerInterface from "common/src/logger/LoggerInterface.js";
+import Channel from "common/src/adapters/queue/rabbitMq/Channel.ts";
+import OnMessageInterfaceV2 from "common/src/adapters/queue/OnMessageInterfaceV2.ts";
+import Exchange from "common/src/adapters/queue/rabbitMq/Exchange.js";
 
 import { RouteInterface } from "../../RouteInterface.ts";
 import VehicleRepositoryInterface from "../../../../../common/src/repositories/VehicleRepositoryInterface.ts";
@@ -9,16 +13,15 @@ import ContainsLockCheck from "../../../../../common/src/vehicle/components/lock
 
 export class Lock implements RouteInterface {
   private _path: string = "/vehicle/:id/lock";
-  private _vehicleRepository: VehicleRepositoryInterface;
-  private _action_responses: ExchangeQueue;
 
   public constructor(
-    vehicleRepository: VehicleRepositoryInterface,
-    action_responses: ExchangeQueue,
-  ) {
-    this._vehicleRepository = vehicleRepository;
-    this._action_responses = action_responses;
-  }
+    private _vehicleRepository: VehicleRepositoryInterface,
+    private _channel: Channel,
+    private _handleResponse: OnMessageInterfaceV2,
+    private _exchange: Exchange,
+    private _applicationName: string,
+    private _logger: LoggerInterface,
+  ) {}
 
   public init(router: ExpressRouter) {
     /**
@@ -121,19 +124,32 @@ export class Lock implements RouteInterface {
       return;
     }
 
-    if (!ContainsLockCheck.run(vehicle.model) || vehicle.model.lock === undefined) {
+    if (
+      !ContainsLockCheck.run(vehicle.model) ||
+      vehicle.model.lock === undefined
+    ) {
       res.status(422).json({ message: "Vehicle does not support locking" });
       return;
     }
 
-    const actionResponsesQueueInitiated = await this._action_responses.init();
+    const actionResponses = new ExchangeQueue(
+      this._channel,
+      this._handleResponse,
+      this._handleResponse,
+      this._exchange,
+      this._applicationName,
+      this._logger,
+      true,
+    );
+
+    const actionResponsesQueueInitiated = await actionResponses.init();
 
     if (actionResponsesQueueInitiated === false) {
       res.status(503).json({ message: "Service unavailable" });
       return;
     }
 
-    const consumptionPromise = this._action_responses.consumeWithTimeout(20000, {
+    const consumptionPromise = actionResponses.consumeWithTimeout(20000, {
       vehicleId: vehicle.id,
       targetState: LockComponent.LOCKED,
     });
@@ -148,9 +164,21 @@ export class Lock implements RouteInterface {
       return;
     }
 
+    const imei = vehicle.model.ioT?.network?.getImeiOfFirstConnectedModule();
+
+    this._logger.info(
+      `Lock request forwarded successfully; vehicle id: ${vehicle.id}, imei: ${imei}`,
+      Lock.name,
+    );
+
     const locked = await consumptionPromise;
 
     if (!locked) {
+      this._logger.info(
+        `Lock failed; vehicle id: ${vehicle.id}, imei: ${imei}`,
+        Lock.name,
+      );
+
       res.status(503).json({
         message: "Vehicle could not be locked. Response stated failed locking.",
       });

--- a/connector/userApi/src/routes/v1/vehicle/lock/HandleLockResponseV2.ts
+++ b/connector/userApi/src/routes/v1/vehicle/lock/HandleLockResponseV2.ts
@@ -1,13 +1,14 @@
+import LoggerInterface from "common/src/logger/LoggerInterface.ts";
+
 import { Lock } from "../../../../../../common/src/vehicle/components/lock/Lock.ts";
 import { ActionStateFromJsonInterface } from "../../../../../../common/src/vehicle/model/actions/json/ActionStateFromJsonInterface.ts";
 import { OnMessageInterfaceV2 } from "../../../../../../common/src/adapters/queue/OnMessageInterfaceV2.ts";
 
 export class HandleLockResponseV2 implements OnMessageInterfaceV2 {
-  private _actionStateFromJson: ActionStateFromJsonInterface;
-
-  constructor(actionRequestJsonConverter: ActionStateFromJsonInterface) {
-    this._actionStateFromJson = actionRequestJsonConverter;
-  }
+  constructor(
+    private _actionStateFromJson: ActionStateFromJsonInterface,
+    private _logger: LoggerInterface,
+  ) {}
 
   public async run(
     actionRequestAsString: string,
@@ -16,7 +17,10 @@ export class HandleLockResponseV2 implements OnMessageInterfaceV2 {
       targetState: typeof Lock.LOCKED | typeof Lock.UNLOCKED;
     },
   ): Promise<boolean | undefined> {
-    //TODO: handle incorrect payload
+    this._logger.info(
+      `Received action response: ${actionRequestAsString}`,
+      HandleLockResponseV2.name,
+    );
 
     const actionRequest = this._actionStateFromJson.run(actionRequestAsString);
 

--- a/infrastructure/podman/testing/compose.yml
+++ b/infrastructure/podman/testing/compose.yml
@@ -20,9 +20,7 @@ services:
     depends_on:
       - rabbitmq
     volumes:
-      - ../../../connector/processors/actionRequests/fromUserApiToQueue:/usr/src/app/connector/processors/actionRequests/fromUserApiToQueue
-      - ../../../connector/common:/usr/src/app/connector/common
-      - ../../../modules:/usr/src/app/modules
+      - ../../../:/usr/src/app/
       - shared:/tmp/vc-shared
     environment:
       INTERNAL: ${INTERNAL}
@@ -37,9 +35,7 @@ services:
     depends_on:
       - rabbitmq
     volumes:
-      - ../../../connector/processors/fromTcpInterfaceMessages:/usr/src/app/connector/processors/fromTcpInterfaceMessages
-      - ../../../connector/common:/usr/src/app/connector/common
-      - ../../../modules:/usr/src/app/modules
+      - ../../../:/usr/src/app/
       - shared:/tmp/vc-shared
     environment:
       INTERNAL: ${INTERNAL}
@@ -56,8 +52,7 @@ services:
     depends_on:
       - rabbitmq
     volumes:
-      - ../../../connector/tcpInterface:/usr/src/app/connector/tcpInterface
-      - ../../../connector/common:/usr/src/app/connector/common
+      - ../../../:/usr/src/app/
       - shared:/tmp/vc-shared
     environment:
       RABBITMQ_HOST: rabbitmq
@@ -74,8 +69,7 @@ services:
     depends_on:
       - rabbitmq
     volumes:
-      - ../../../connector/userApi:/usr/src/app/connector/userApi
-      - ../../../connector/common:/usr/src/app/connector/common
+      - ../../../:/usr/src/app/
       - shared:/tmp/vc-shared
     environment:
       RABBITMQ_HOST: rabbitmq

--- a/modules/protocols/theSimpleProtocol/test/connector/0_1/Lock.test.acceptance.ts
+++ b/modules/protocols/theSimpleProtocol/test/connector/0_1/Lock.test.acceptance.ts
@@ -21,7 +21,7 @@ describe("Lock v0_1", () => {
     async () => {
       const imei = faker.string.numeric(15);
       const protocolVersion = "0_1";
-      const trackingId = "1234AAAA56789";
+      const trackingId = faker.string.alphanumeric(10);
 
       const sampleData = {
         modelName: "LockableScooter",
@@ -90,7 +90,7 @@ describe("Lock v0_1", () => {
     async () => {
       const imei = faker.string.numeric(15);
       const protocolVersion = "0_1";
-      const trackingId = "1234AAAA56789";
+      const trackingId = faker.string.alphanumeric(10);
 
       const sampleData = {
         modelName: "LockableScooter",

--- a/modules/protocols/theSimpleProtocol/test/connector/0_2/Lock.test.acceptance.ts
+++ b/modules/protocols/theSimpleProtocol/test/connector/0_2/Lock.test.acceptance.ts
@@ -21,7 +21,7 @@ describe("Lock v0_2", () => {
     async () => {
       const imei = faker.string.numeric(15);
       const protocolVersion = "0_2";
-      const trackingId = "1234AAAA56789";
+      const trackingId = faker.string.alphanumeric(10);
 
       const sampleData = {
         modelName: "LockableScooter",
@@ -90,7 +90,7 @@ describe("Lock v0_2", () => {
     async () => {
       const imei = faker.string.numeric(15);
       const protocolVersion = "0_2";
-      const trackingId = "1234AAAA56789";
+      const trackingId = faker.string.alphanumeric(10);
 
       const sampleData = {
         modelName: "LockableScooter",

--- a/modules/protocols/theSimpleProtocol/test/connector/FakeTcpVehicle.ts
+++ b/modules/protocols/theSimpleProtocol/test/connector/FakeTcpVehicle.ts
@@ -58,8 +58,8 @@ export class FakeTcpVehicle {
       this._logger.info("Connection closed");
       this._connected = false;
     });
-    this._socket.on(Socket.EVENT_ON_DATA, (data: Buffer) => {
-      this.onData(data);
+    this._socket.on(Socket.EVENT_ON_DATA, async (data: Buffer) => {
+      await this.onData(data);
     });
   }
 
@@ -74,7 +74,7 @@ export class FakeTcpVehicle {
     });
   }
 
-  private onData(data: Buffer): boolean {
+  private async onData(data: Buffer): Promise<boolean> {
     this._logger.info("new data received");
 
     if (data.length === 1 && data[0] === LINE_FEED) {
@@ -100,9 +100,12 @@ export class FakeTcpVehicle {
       return false;
     }
 
-    const responseMessageLineWithDateTime = responseMessageLine.replace(/\{(.*?)\}/g, (_, dateString) => {
+    const responseMessageLineWithDateTime = responseMessageLine.replace(/\{(.*?)\}/g, () => {
       return new Date().toISOString();
     });
+
+    // TODO: check necessity of stmt, removing breaks acceptance test, because response prior to consumption?
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     return this.sendMessage(responseMessageLineWithDateTime);
   }

--- a/simulator/src/index.ts
+++ b/simulator/src/index.ts
@@ -32,11 +32,6 @@ import { GetRandomCoordinateForLocation } from "./vehicles/position/GetRandomCoo
 import { OpenStreetMap } from "./adapters/OpenStreetMap.ts";
 import loadContext from "./bootstrap/loadContext.ts";
 
-function getRandomElements(arr: string[], count: number): string[] {
-  const shuffled = arr.sort(() => 0.5 - Math.random());
-  return shuffled.slice(0, count);
-}
-
 async function run() {
   dotenv.config();
 
@@ -55,20 +50,16 @@ async function run() {
 
   const imeis: string[] = config.imeis;
 
+  const logger = new Logger(LogLevels.DEBUG_LEVEL);
   if (imeis.length === 0) {
     throw new Error("No imeis found in config");
   }
 
+  logger.info(`Vehicle amount: ${imeis.length}`);
+
   const context = await loadContext();
 
-  const fleetUsageInPercent = 50;
-
-  const amountOfVehicles = Math.floor((imeis.length * fleetUsageInPercent) / 100);
-
-  const randomImeis = getRandomElements(imeis, amountOfVehicles);
   const protocolConfigs = config.protocolConfigs as ProtocolConfigs;
-
-  const logger = new Logger(LogLevels.DEBUG_LEVEL);
   const hashColoredLogger = new HashColoredLogger(LogLevels.DEBUG_LEVEL);
   const rabbitMq = new RabbitMqConnection(
     "amqp://user:password@localhost:5672",
@@ -77,7 +68,7 @@ async function run() {
   const rabbitMqChannel = new Channel(rabbitMq, logger);
   const vehicles = await new SetupSimulatedVehicles(
     logger,
-    randomImeis,
+    imeis,
     rabbitMqChannel,
     hashColoredLogger,
     protocolConfigs,


### PR DESCRIPTION
fix(userApi): per lock/unlock request new consumption queue is created
feat: added test cases
feat: more logging
fix(simulator): do not randomize vehicles for setup
fix(connector/common): handle init response in workerQueue
fix(infrastructure): adjust volume mount as deps handled via npm workspaces now